### PR TITLE
make public button active on persist, show correct url

### DIFF
--- a/ComponentsInitialization.js
+++ b/ComponentsInitialization.js
@@ -404,13 +404,17 @@ define(function(require) {
         var toggleClickHandler = function() {
             if (!window.Project.isPublic()) {
                 var title = "Your project is now public. This is its URL for you to share!";
-                var url = window.osbURL + "?explorer_id="+Project.getId();
+                var url = window.osbURL + "projects/" + Project.getName() + "?explorer_id=" + Project.getId();
                 GEPPETTO.ModalFactory.infoDialog(title, url);
             }
         };
 
         var toggleEventHandler = function(component) {
             GEPPETTO.on(GEPPETTO.Events.Project_loaded, function() {
+                component.evaluateState();
+            });
+
+	    GEPPETTO.on(GEPPETTO.Events.Project_persisted, function() {
                 component.evaluateState();
             });
 


### PR DESCRIPTION
This relies on changes to redmine (https://github.com/OpenSourceBrain/redmine/pull/304), and in particular it is only working for projects persisted after these changes. The reason being that geppetto project names/ids were previously the name of the neuroml network (e.g. `network_ACnet2`) and as far as I know (@tarelli?) they store no reference to the redmine project name (e.g. `acnet2`). I have changed things so that the latter is now used as the geppetto project name, and thus geppetto can give URLs like [opensourcebrain.org/projects/acnet2?explorer_id=345](http://opensourcebrain.org/projects/acnet2?explorer_id=345)